### PR TITLE
uj ecoXXX.streaming4u.hu streamek tamogatasa

### DIFF
--- a/engine/tv_servlet.js
+++ b/engine/tv_servlet.js
@@ -53,6 +53,11 @@ var server = http.createServer(function(request, response) {
             });
             response.end();
         });
+    else if ((get.substring(0, 3) === 'eco') && (channels.indexOf(get) !== -1)) {
+        app.getChannel(get, function (url) {
+            response.writeHead(302, {
+                'Location': "http://" + url.substr(8)
+            }); 
         log('Inditva: ' + get);
     }
     else if (get.substring(0, 11) === 'setprogram=') {


### PR DESCRIPTION
az ittott.tv uj eco_CHANNELID HLS streamjeinek tamogatasa http-n
https-en nem mennek ezek a streamek a teszt Pi-n ami nalam van, tanusitvanyhiba miatt, amit lusta vagyok debugolni

https stream URL trivialis, 59-es sor:

            'Location': "http://" + url.substr(8)

helyett:

            'Location': url
