### PR TITLE
Fix a legujabb Kodi verziokhoz, EPG tovabbfejlesztes, kepek, stb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/*
 *.iws
+*~
 /out/
 .idea_modules/
 atlassian-ide-plugin.xml
@@ -14,3 +15,4 @@ epg.xml
 tv_servlet.sh
 shelf/*
 log.log
+engine/package-lock.json

--- a/config.js.sample
+++ b/config.js.sample
@@ -2,7 +2,10 @@
 
 const config = {
     preUrl:             'http://localhost:8081/', // Az a szerver ip cim/host ahol a servlet fut
-    recordingLocation:  '/home/user/TV/', // path, ahova a felvetelek mentesre kerulnek
+    recordingLocation:  '/home/user/TV/',         // path, ahova a felvetelek mentesre kerulnek
+    genFilesDir:	'../generated-files',     // konyvtar, ahova a channels.m3u es epg.xml fajl mentesre 
+                                                  // kerul, lehet relativ (engine/ -hez kepest) vagy abszolut.
+                                                  // Ha nem letezik, automatikusan letrehozasra kerul.
     USERDATA: {
         /**
          * Belepesi adatok

--- a/engine/epg.js
+++ b/engine/epg.js
@@ -6,6 +6,8 @@
 var jsdom = require('jsdom');
 var $ = require('jquery')(jsdom.jsdom().defaultView);
 var request = require('request').defaults({jar: true});
+var dateFormat = require('dateformat');
+const htmlToText = require('html-to-text');
 
 /**
  * Olvasnivalók:
@@ -15,75 +17,77 @@ var request = require('request').defaults({jar: true});
 class Epg {
     constructor () {
         this.channelEpgUrls = {
-            'eco2_M2_HD-HLS': 'https://musor.tv/heti/tvmusor/M2',
-            'eco_Duna_HD-HLS': 'https://musor.tv/heti/tvmusor/DUNA',
-            'eco2_M4Sport_HD-HLS': 'https://musor.tv/heti/tvmusor/M4_SPORT',
-            'eco3_DunaWorld_HD-HLS': 'https://musor.tv/heti/tvmusor/DUNAWORLD',
-            'eco2_M3_SD-HLS': 'https://musor.tv/heti/tvmusor/M3',
-            'eco3_M5_HD-HLS': 'https://musor.tv/heti/tvmusor/M5',
-            'eco2_ATV_SD-HLS': 'https://musor.tv/heti/tvmusor/ATV',
-            'eco2_AXN_SD-HLS': 'https://musor.tv/heti/tvmusor/AXN',
-            'eco_BonumTV_SD-HLS': 'https://musor.tv/heti/tvmusor/BONUM',
-            'eco2_ComedyCentral_SD-HLS': 'https://musor.tv/heti/tvmusor/COMEDY',
-            'eco_ComedyCentralFam_SD-HLS': 'https://musor.tv/heti/tvmusor/COMEDY_CENTRAL_FAMILY',
-            'eco2_DaVinci_SD-HLS': 'https://musor.tv/heti/tvmusor/DAVINCI',
-            'eco3_DikhTV_HD-HLS': 'https://musor.tv/heti/tvmusor/DIKH_TV',
-            'eco_DuckTV_SD-HLS': 'https://musor.tv/heti/tvmusor/DUCKTV',
-            'eco_EchoTV_SD-HLS': 'https://musor.tv/heti/tvmusor/ECHOTV',
-            'eco2_EuroNews_SD-HLS': 'https://musor.tv/heti/tvmusor/EURONEWS',
-            'eco2_Film4_SD-HLS': 'https://musor.tv/heti/tvmusor/FILM4',
-            'eco_FitHD_SD-HLS': 'https://musor.tv/heti/tvmusor/FIT_HD',
-            'eco_HirTV_SD-HLS': 'https://musor.tv/heti/tvmusor/HIRTV',
-            'eco_Moziplus_SD-HLS': 'https://musor.tv/heti/tvmusor/MOZI_PLUSZ',
-            'eco3_MTV_SD-HLS': 'https://musor.tv/heti/tvmusor/MTVHU',
-            'eco2_MusicChannel_SD-HLS': 'https://musor.tv/heti/tvmusor/MUSICCHANNEL',
-            'eco2_Nickelodeon_SD-HLS': 'https://musor.tv/heti/tvmusor/NICKELODEON',
-            'eco2_Ozone_SD-HLS': 'https://musor.tv/heti/tvmusor/OZONENETWORK',
-            'eco_Fem3_SD-HLS': 'https://musor.tv/heti/tvmusor/FEM3',
-            'eco2_Prime_SD-HLS': 'https://musor.tv/heti/tvmusor/PRIME',
-            'eco2_RTLplus_SD-HLS': 'https://musor.tv/heti/tvmusor/RTL_PLUSZ',
-            'eco_RTLSpike_SD-HLS': 'https://musor.tv/heti/tvmusor/RTL_SPIKE',
-            'eco_MagyarSlagerTV_SD-HLS': 'https://musor.tv/heti/tvmusor/SLAGERTV',
-            'eco2_SonyMax_SD-HLS': 'https://musor.tv/heti/tvmusor/SONY_MAX',
-            'eco_SonyMovie_SD-HLS': 'https://musor.tv/heti/tvmusor/SONY_MOVIE_CHANNEL',
-            'eco2_TV4_SD-HLS': 'https://musor.tv/heti/tvmusor/TV4',
-            'eco_TotalDanceTV_SD-HLS': 'https://musor.tv/heti/tvmusor/TOTALDANCE_TV',
-            'eco3_Zenebutik_SD-HLS': 'https://musor.tv/heti/tvmusor/ZENEBUTIK',
-            'eco_Story4_SD-HLS': 'https://musor.tv/heti/tvmusor/STORY4',
-            'eco_SuperTV2_SD-HLS': 'https://musor.tv/heti/tvmusor/SUPERTV2',
-            'eco2_CoolTV_SD-HLS': 'https://musor.tv/heti/tvmusor/COOL',
-            'eco2_Filmplus_SD-HLS': 'https://musor.tv/heti/tvmusor/FILMPLUS',
-            'eco_Filmbox_SD-HLS': 'https://musor.tv/heti/tvmusor/FILMBOX',
-            'eco3_FixTV_SD-HLS': 'https://musor.tv/heti/tvmusor/FIXTV',
-            'eco2_NatGeo_SD-HLS': 'https://musor.tv/heti/tvmusor/NATGEO',
-            'eco2_RTL2_SD-HLS': 'https://musor.tv/heti/tvmusor/RTL2',
-            'eco_RTLKlub_HD-HLS': 'https://musor.tv/heti/tvmusor/RTL',
-            'eco2_TravelChannel_SD-HLS': 'https://musor.tv/heti/tvmusor/TRAVEL',
-            'eco2_TV2_HD-HLS': 'https://musor.tv/heti/tvmusor/TV2',
-            'eco2_Viasat3_SD-HLS': 'https://musor.tv/heti/tvmusor/VIASAT3',
-            'eco2_Viasat6_SD-HLS': 'https://musor.tv/heti/tvmusor/VIASAT6',
-            'eco_Boomerang_SD-HLS': 'https://musor.tv/heti/tvmusor/BOOMERANG',
-            'eco2_Disney_SD-HLS': 'https://musor.tv/heti/tvmusor/DISNEY',
-            'eco_DoQ_SD-HLS': 'https://musor.tv/heti/tvmusor/DOQ',
-            'eco2_FandH_SD-HLS': 'https://musor.tv/heti/tvmusor/FISHING_HUNTING',
-            'eco_Galaxy4_SD-HLS': 'https://musor.tv/heti/tvmusor/GALAXY',
-            'eco_HitMusicChannel_SD-HLS': 'https://musor.tv/heti/tvmusor/HIT_MUSIC',
-            'eco3_HetiTV_SD-HLS': 'https://musor.tv/heti/tvmusor/HETI_TV',
-            'eco2_Izaura_SD-HLS': 'https://musor.tv/heti/tvmusor/IZAURA_TV',
-            'eco2_LifeTV_SD-HLS': 'https://musor.tv/heti/tvmusor/LIFE_TV',
-            'eco3_MuzsikaTV_SD-HLS': 'https://musor.tv/heti/tvmusor/MUZSIKATV',
-            'eco_NatGeoWild_SD-HLS': 'https://musor.tv/heti/tvmusor/NATGEOWILD',
-            'eco2_SpilerTV_SD-HLS': 'https://musor.tv/heti/tvmusor/SPILER_TV',
-            'eco2_ViasatExplore_SD-HLS': 'https://musor.tv/heti/tvmusor/VIASATEXP',
-            'eco2_ViasatHistory_SD-HLS': 'https://musor.tv/heti/tvmusor/VIASATHIST',
-            'eco_ViasatNature_SD-HLS': 'https://musor.tv/heti/tvmusor/VIASATNAT'
+            'M1': 'https://musor.tv/heti/tvmusor/M1',
+            'M2': 'https://musor.tv/heti/tvmusor/M2',
+            'Duna': 'https://musor.tv/heti/tvmusor/DUNA',
+            'M4Sport': 'https://musor.tv/heti/tvmusor/M4_SPORT',
+            'DunaWorld': 'https://musor.tv/heti/tvmusor/DUNAWORLD',
+//            'M3': 'https://musor.tv/heti/tvmusor/M3',
+            'M5': 'https://musor.tv/heti/tvmusor/M5',
+            'ATV': 'https://musor.tv/heti/tvmusor/ATV',
+            'ATVSpirit': 'https://musor.tv/heti/tvmusor/ATV_SPIRIT',
+            'AXN': 'https://musor.tv/heti/tvmusor/AXN',
+            'BonumTV': 'https://musor.tv/heti/tvmusor/BONUM',
+            'ComedyCentral': 'https://musor.tv/heti/tvmusor/COMEDY',
+            'ComedyCentralFam': 'https://musor.tv/heti/tvmusor/COMEDY_CENTRAL_FAMILY',
+            'DaVinci': 'https://musor.tv/heti/tvmusor/DAVINCI',
+            'DikhTV': 'https://musor.tv/heti/tvmusor/DIKH_TV',
+            'DuckTV': 'https://musor.tv/heti/tvmusor/DUCKTV',
+            'EchoTV': 'https://musor.tv/heti/tvmusor/ECHOTV',
+            'EuroNews': 'https://musor.tv/heti/tvmusor/EURONEWS',
+            'Film4': 'https://musor.tv/heti/tvmusor/FILM4',
+            'FitHD': 'https://musor.tv/heti/tvmusor/FIT_HD',
+            'HirTV': 'https://musor.tv/heti/tvmusor/HIRTV',
+            'Moziplus': 'https://musor.tv/heti/tvmusor/MOZI_PLUSZ',
+            'MTV': 'https://musor.tv/heti/tvmusor/MTVHU',
+            'MusicChannel': 'https://musor.tv/heti/tvmusor/MUSICCHANNEL',
+            'Nickelodeon': 'https://musor.tv/heti/tvmusor/NICKELODEON',
+            'Ozone': 'https://musor.tv/heti/tvmusor/OZONE_TV',
+            'Fem3': 'https://musor.tv/heti/tvmusor/FEM3',
+            'Prime': 'https://musor.tv/heti/tvmusor/PRIME',
+            'RTLplus': 'https://musor.tv/heti/tvmusor/RTL_PLUSZ',
+            'RTLSpike': 'https://musor.tv/heti/tvmusor/RTL_SPIKE',
+            'MagyarSlagerTV': 'https://musor.tv/heti/tvmusor/SLAGERTV',
+            'SonyMax': 'https://musor.tv/heti/tvmusor/SONY_MAX',
+            'SonyMovie': 'https://musor.tv/heti/tvmusor/SONY_MOVIE_CHANNEL',
+            'TV4': 'https://musor.tv/heti/tvmusor/TV4',
+            'TotalDanceTV': 'https://musor.tv/heti/tvmusor/TOTALDANCE_TV',
+            'Zenebutik': 'https://musor.tv/heti/tvmusor/ZENEBUTIK',
+            'Story4': 'https://musor.tv/heti/tvmusor/STORY4',
+            'SuperTV2': 'https://musor.tv/heti/tvmusor/SUPERTV2',
+            'CoolTV': 'https://musor.tv/heti/tvmusor/COOL',
+            'Filmplus': 'https://musor.tv/heti/tvmusor/FILMPLUS',
+            'Filmbox': 'https://musor.tv/heti/tvmusor/FILMBOX',
+            'FixTV': 'https://musor.tv/heti/tvmusor/FIXTV',
+            'NatGeo': 'https://musor.tv/heti/tvmusor/NATGEO',
+            'RTL2': 'https://musor.tv/heti/tvmusor/RTL2',
+            'RTLKlub': 'https://musor.tv/heti/tvmusor/RTL',
+            'TravelChannel': 'https://musor.tv/heti/tvmusor/TRAVEL',
+            'TV2': 'https://musor.tv/heti/tvmusor/TV2',
+            'Viasat3': 'https://musor.tv/heti/tvmusor/VIASAT3',
+            'Viasat6': 'https://musor.tv/heti/tvmusor/VIASAT6',
+            'Boomerang': 'https://musor.tv/heti/tvmusor/BOOMERANG',
+            'Disney': 'https://musor.tv/heti/tvmusor/DISNEY',
+            'DoQ': 'https://musor.tv/heti/tvmusor/DOQ',
+            'FandH': 'https://musor.tv/heti/tvmusor/FISHING_HUNTING',
+            'Galaxy4': 'https://musor.tv/heti/tvmusor/GALAXY',
+            'HitMusicChannel': 'https://musor.tv/heti/tvmusor/HIT_MUSIC',
+            'HetiTV': 'https://musor.tv/heti/tvmusor/HETI_TV',
+            'Izaura': 'https://musor.tv/heti/tvmusor/IZAURA_TV',
+            'LifeTV': 'https://musor.tv/heti/tvmusor/LIFE_TV',
+            'MuzsikaTV': 'https://musor.tv/heti/tvmusor/MUZSIKATV',
+            'NatGeoWild': 'https://musor.tv/heti/tvmusor/NATGEOWILD',
+            'SpilerTV': 'https://musor.tv/heti/tvmusor/SPILER_TV',
+            'ViasatExplore': 'https://musor.tv/heti/tvmusor/VIASATEXP',
+            'ViasatHistory': 'https://musor.tv/heti/tvmusor/VIASATHIST',
+            'ViasatNature': 'https://musor.tv/heti/tvmusor/VIASATNAT'
         };
 
         /*
          * Template fájlok az xml generálásához
          */
         this.channelTemplate = '<channel id="id:id"><display-name lang="hu">:channelName</display-name></channel>';
-        this.programmeTemplate = '<programme start=":start +0100" stop=":end +0100" channel="id:id"><title lang="hu">:programme</title></programme>';
+        this.programmeTemplate = '<programme start=":start" stop=":stop" channel="id:id">:programme</programme>';
         this.xmlContainer = '<?xml version="1.0" encoding="utf-8" ?><tv>:content</tv>';
     }
 
@@ -104,50 +108,28 @@ class Epg {
         return channel;
     }
 
-    getProgrammeTemplate (id, start, end, programme) {
+    getProgrammeTemplate (id, start, end, show) {
         var startCorrect = new Date(start);
-        // időzóna korrekció
-        startCorrect.setHours(startCorrect.getHours() - 3);
-
         var endCorrect = new Date(end);
-        // időzóna korrekció
-        endCorrect.setHours(endCorrect.getHours() - 3);
 
         // Nem lehet egyszerre egy csatornán egy másodpercben egy csatornának kezdete és vége, így kivontunk belőle 1 mp-et
         endCorrect.setMilliseconds(endCorrect.getMilliseconds() - 1000);
 
+        var programme = '<title lang="hu">' + show.title + '</title>';
+        if (show.subTitle) programme += '<sub-title>' + show.subTitle + '</sub-title>';
+        if (show.icon) programme += '<icon src="' + show.icon + '"/>';
+        if (show.description) programme += '<desc>' + show.description + '</desc>';
+        if (show.year) programme += '<date>' + show.year + '</date>';
+
         return this.programmeTemplate
             .replace(':id', id)
             .replace(':start', this.formatDate(startCorrect))
-            .replace(':end', this.formatDate(endCorrect))
+            .replace(':stop', this.formatDate(endCorrect))
             .replace(':programme', programme);
     }
 
     formatDate (date) {
-        var d       = new Date(date);
-        var year    = d.getFullYear();
-        var month   = d.getMonth()+1;
-        var day     = d.getDate();
-        var hour    = d.getHours();
-        var minute  = d.getMinutes();
-        var second  = d.getSeconds();
-        if(month.toString().length == 1) {
-            month = '0'+month;
-        }
-        if(day.toString().length == 1) {
-            day = '0'+day;
-        }
-        if(hour.toString().length == 1) {
-            hour = '0'+hour;
-        }
-        if(minute.toString().length == 1) {
-            minute = '0'+minute;
-        }
-        if(second.toString().length == 1) {
-            second = '0'+second;
-        }
-
-        return '' + year+month+day+hour+minute+second;
+        return dateFormat(date, "yyyymmddHHMMss o");
     }
 
     /**
@@ -169,11 +151,19 @@ class Epg {
                 headers: headers
             },
             function (error, response, body) {
-                $.each($(body).find('[itemtype="https://schema.org/BroadcastEvent"]'), function (index, program) {
+                $.each($(body).find('div[id^="period_"]').find('[itemtype="https://schema.org/BroadcastEvent"]'), function (index, program) {
+                    var categoryYear = $(program).find('[itemprop="description"]').html().split(',');
+                    var screenshot = $(program).find('div.smartpe_screenshot img').attr('src');
+                    if (screenshot && screenshot.indexOf('//') != -1) {
+                        screenshot = 'https://' + screenshot.replace('//','');
+                    }
                     var show = {
                         startDate: $(program).find('[itemprop="startDate"]').attr('content'),
-                        name: $(program).find('[itemprop="name"] a').html(),
-                        description: $(program).find('[itemprop="description"]').html()
+                        title: htmlToText.fromString($(program).find('[itemprop="name"] a').html()),
+                        subTitle: htmlToText.fromString(categoryYear.length > 1 ? categoryYear[0] : ''),
+                        year: categoryYear.length > 1 ? categoryYear[1] : categoryYear[0],
+                        icon: screenshot ? screenshot : '',
+                        description: htmlToText.fromString($(program).find('.smartpe_progentrylong').html())
                     };
 
                     shows.push(show);

--- a/engine/package.json
+++ b/engine/package.json
@@ -4,9 +4,13 @@
   "description": "Ittott.tv nodejs servlet külső lejátszóhoz",
   "main": "tv_servlet.js",
   "dependencies": {
+    "dateformat": "^3.0.3",
+    "finalhandler": "^1.1.2",
+    "html-to-text": "^5.1.1",
     "jquery": "^3.1.1",
     "jsdom": "^9.9.1",
     "readline-sync": "^1.4.5",
+    "serve-static": "^1.14.1",
     "webpack": "^1.14.0"
   },
   "devDependencies": {

--- a/engine/tv_servlet.js
+++ b/engine/tv_servlet.js
@@ -4,6 +4,11 @@
 var http = require('http');
 const exec = require('child_process').exec;
 var log = require('./log.js');
+const config = require('../config.js');
+
+var finalhandler = require('finalhandler');
+var serveStatic = require('serve-static');
+var serve = serveStatic(config.genFilesDir);
 
 /**
  * Ittott.tv vezérlőprogramja, ez épít "tunnel"-t az ittotttv és a kodi közé.
@@ -22,7 +27,6 @@ var Scheduler = require('./scheduler.js');
 /**
  * User konfiguráció. Benne van a .gitignore-ban, a config.js.sample a mintája
  */
-const config = require('../config.js');
 const USERDATA = config.USERDATA;
 
 log('#############    Kezdés     ##############');
@@ -36,9 +40,15 @@ var server = http.createServer(function(request, response) {
     var get   = decodeURIComponent(request.url.substring(1)),
         param = get;
 
-    get = get.substring(get.length-4, 0);
+    get = get.substring(get.length-5, 0);
+    var url = require('url').parse(request.url);
 
-    if ((get.substring(0, 4) === 'http') || get.substring(0, 4) === 'rtmp') {
+    if (url.pathname.startsWith('/static')) {
+        request.url = request.url.replace('/static', '');
+        var done = finalhandler(request, response);
+        serve(request, response, done);
+    }
+    else if ((get.substring(0, 4) === 'http') || get.substring(0, 4) === 'rtmp') {
         response.writeHead(302, {
             'Location': get
         });
@@ -57,7 +67,7 @@ var server = http.createServer(function(request, response) {
         app.getChannel(get, function (url) {
             response.writeHead(302, {
                 'Location': 'http://' + url.substr(8)
-            }); 
+            });
             response.end();
         });
         log('Inditva: ' + get);
@@ -83,13 +93,14 @@ try {
      * Ezen fog hallgatni a servlet
      * @type {Number}
      */
-    var listenPort = parseInt(config.preUrl.split(':')[2].replace('/', ''));
-    if (!isNaN(listenPort) && listenPort > 0) {
-        server.listen(listenPort);
+    var listenIP = config.preUrl.split(':')[1].replace(/\//g, '');
+    var listenPort = parseInt(config.preUrl.split(':')[2].replace(/\//g, ''));
+    if (!isNaN(listenPort) && listenPort > 0 && listenIP) {
+        server.listen(listenPort, listenIP);
         log('Server is listening: ' + config.preUrl);
     }
     else {
-        log(' HIBA! Érvénytelen megadott port: ' + listenPort);
+        log(' HIBA! Érvénytelen megadott port vagy IP cim => [IP: ' + listenIP + ' Port: ' + listenPort + "]");
         return;
     }
 


### PR DESCRIPTION
Fixes #11 

 1. A generalt .m3u allomanyban .m3u8 kiterjesztessel szerepelnek
    a target URL-ek, ugyanis a legujabb Kodi verziok az .m3u link-
    eket egyszeruen ignoraljak, kivalasztaskor nem triggerelodik
    a csatorna betoltese (sok idobe telt, mig erre sikerult rajonni)

 2. A generalt channels.m3u es epg.xml fajlok elerhetoek HTTP-n
    is: `http://<IP>:<Port>/static/{channels.m3u, epg.xml}`, igy
    amennyiben a servlet nem a Kodit futtato eszkozon fut, nem
    kell smb, nfs stb-vel szorakozni, az IPTV Simple Client-ben
    egyszeruen megadhato a fenti URL.

 3. Kepek mind a csatornakhoz, mind a musorokhoz (ha elerheto).

 4. EPG <> csatorna mapping javitasok, a friss ittott.tv (alap +
    plusz csomag) csatornalista alapjan.

 5. Reszletesebb EPG informacio + musor ikon (ha elerheto)

 6. A config.js -ben az IP cim / host eddig nem volt hasznalva, igy a
     servlet az osszes halozati interfeszen figyelt. Ezentul kizarolag a 
     megadott IP cim / hoszt nevnek megfelelo interfeszt hasznalja,
     ami lehet 0.0.0.0 (osszes interfesz) is.

 7. A config.js -be bekerult egy uj opcio a generalt fajlok (.m3u, .xml)
    konyvtarahoz, alapertelmezetten ez a "generated-files".

 8. A korabban fix +3 oras idoeltolas megszuntetve! Erre, ha a rendszer
    ido es legfokepp idozona beallitasai helyesek, nincsen szukseg,
    a Node.js datumkezelo funkcioi korrekten kezelik az idozonat,
    az epg.xml-be mindig a helyi idozonanak megfelelo idobelyeg kerul.